### PR TITLE
Update package list

### DIFF
--- a/index.md
+++ b/index.md
@@ -28,9 +28,7 @@ to add them here.**
 * [Gurobify](https://github.com/jesselansdown/Gurobify) ([Homepage](https://jesselansdown.github.io/Gurobify)): A GAP interface to Gurobi Optimizer
 * [IncidenceStructures](https://github.com/nagygp/IncidenceStructures) ([Homepage](https://nagygp.github.io/IncidenceStructures)): GAP implementation of abstract incidence structures
 * [Itest](https://github.com/isadofschi/itest): An implementation of Barmak and Minian's I-test
-* [ModularGroup](https://github.com/AG-Weitze-Schmithusen/ModularGroup) ([Homepage](https://ag-weitze-schmithusen.github.io/ModularGroup/)): A collection of algorithms for computing with finite-index subgroups of (P)SL(2,Z).
 * [orders](https://github.com/feisele/orders): A GAP package for computations with orders over the p-adic integers
-* [Origami](https://github.com/AG-Weitze-Schmithusen/Origami) ([Homepage](https://ag-weitze-schmithusen.github.io/Origami/)): A package for computing the Veech group of square-tiled surfaces which are also known as origamis
 * [PAG](https://github.com/vkrcadinac/PAG) ([Homepage](https://vkrcadinac.github.io/PAG/)): A GAP package for constructing combinatorial objects with prescribed automorphism groups
 * The [PEAL](https://peal.github.io) organisation has several packages for computing with permutation groups:
     * [BacktrackKit](https://github.com/peal/BacktrackKit) ([Homepage](https://peal.github.io/BacktrackKit)): An extensible, easy to understand backtracking framework
@@ -41,8 +39,6 @@ to add them here.**
 * [Satisfiability](https://github.com/MathieuDutSik/Satisfiability): functionality to solve satisfiability constraint problems and access to minisat
 * [semigroupviz](https://github.com/nathancarter/semigroupviz) ([Homepage](https://nathancarter.github.io/semigroupviz)): Visualization tools for semigroups in GAP
 * [SmallCancellation](https://github.com/isadofschi/smallcancellation): Metric and nonmetric small cancellation conditions
-* [SmallClassNr](https://github.com/stertooy/SmallClassNr): Library of finite groups with small class number
-* [TwistedConjugacy](https://github.com/sTertooy/TwistedConjugacy) ([Homepage](https://stertooy.github.io/TwistedConjugacy)): Computation with twisted conjugacy classes
 * [WeylModules](https://github.com/srdoty/WeylModulesNew) ([Homepage](https://srdoty.github.io/WeylModulesNew/)): Functions for doing computations with Weyl modules in positive characteristic for a simple simply-connected algebraic group
 * [YAGS](https://github.com/yags/yags) ([Homepage](http://xamanek.izt.uam.mx/yags)): YAGS - Yet Another Graph System
 

--- a/index.md
+++ b/index.md
@@ -28,6 +28,7 @@ to add them here.**
 * [G2Comp](https://github.com/isadofschi/g2comp): G2Comp/Equivariant 2-complexes
 * [glabella](https://github.com/nagygp/glabella) ([Homepage](https://nagygp.github.io/glabella)): Low level interfaces to graph automorphism and canonical labelling tools
 * [GRPS1024](https://github.com/davidburrell/GRPS1024) ([Homepage](https://davidburrell.github.io/GRPS1024/)): Library of the groups of order 1024
+* [GRPS39](https://github.com/davidburrell/GRPS39) ([Homepage](https://davidburrell.github.io/GRPS39/)): Library of the groups of order 19683
 * [Gurobify](https://github.com/jesselansdown/Gurobify) ([Homepage](https://jesselansdown.github.io/Gurobify)): A GAP interface to Gurobi Optimizer
 * Homology ([Homepage](https://www-ljk.imag.fr/membres/Jean-Guillaume.Dumas/Homology/)): Simplicial Homology Computations
 * IdPGroup ([Homepage](https://www.iaa.tu-bs.de/henschan/so.html)): Identification functions for different p-groups

--- a/index.md
+++ b/index.md
@@ -30,6 +30,7 @@ to add them here.**
 * IdPGroup ([Homepage](https://www.iaa.tu-bs.de/henschan/so.html)): Identification functions for different p-groups
 * [IncidenceStructures](https://github.com/nagygp/IncidenceStructures) ([Homepage](https://nagygp.github.io/IncidenceStructures)): GAP implementation of abstract incidence structures
 * [Itest](https://github.com/isadofschi/itest): An implementation of Barmak and Minian's I-test
+* [NautyTracesInterface](https://github.com/gap-packages/NautyTracesInterface) ([Homepage](https://gap-packages.github.io/NautyTracesInterface)): An interface to nauty
 * [orders](https://github.com/feisele/orders): A GAP package for computations with orders over the p-adic integers
 * [PAG](https://github.com/vkrcadinac/PAG) ([Homepage](https://vkrcadinac.github.io/PAG/)): A GAP package for constructing combinatorial objects with prescribed automorphism groups
 * The [PEAL](https://peal.github.io) organisation has several packages for computing with permutation groups:

--- a/index.md
+++ b/index.md
@@ -20,6 +20,7 @@ to add them here.**
 * [BruhatDecomposition](https://github.com/gap-packages/BruhatDecomposition): Computes the Bruhat decomposition of matrices in classical groups
 * [COCO2P](https://github.com/chpech/COCO2P): GAP-package for the computation with coherent configurations
 * [CoxIterGAP](https://github.com/gap-packages/CoxIterGAP): Wrapper for the [CoxIter](https://github.com/rgugliel/CoxIter) program designed to compute invariants of hyperbolic Coxeter groups
+* CTBlocks ([Homepage](https://www.math.rwth-aachen.de/~Thomas.Breuer/ctblocks)): Blocks of Character Tables
 * [EigenGap](https://github.com/jesselansdown/EigenGap): Using the Eigen C++ library within GAP
 * [FSR](https://github.com/nzidaric/fsr) ([Homepage](https://nzidaric.github.io/fsr)): Feedback Shift Register Package
 * [G2Comp](https://github.com/isadofschi/g2comp): G2Comp/Equivariant 2-complexes

--- a/index.md
+++ b/index.md
@@ -29,6 +29,7 @@ to add them here.**
 * [glabella](https://github.com/nagygp/glabella) ([Homepage](https://nagygp.github.io/glabella)): Low level interfaces to graph automorphism and canonical labelling tools
 * [GRPS1024](https://github.com/davidburrell/GRPS1024) ([Homepage](https://davidburrell.github.io/GRPS1024/)): Library of the groups of order 1024
 * [Gurobify](https://github.com/jesselansdown/Gurobify) ([Homepage](https://jesselansdown.github.io/Gurobify)): A GAP interface to Gurobi Optimizer
+* Homology ([Homepage](https://www-ljk.imag.fr/membres/Jean-Guillaume.Dumas/Homology/)): Simplicial Homology Computations
 * IdPGroup ([Homepage](https://www.iaa.tu-bs.de/henschan/so.html)): Identification functions for different p-groups
 * [IncidenceStructures](https://github.com/nagygp/IncidenceStructures) ([Homepage](https://nagygp.github.io/IncidenceStructures)): GAP implementation of abstract incidence structures
 * [Itest](https://github.com/isadofschi/itest): An implementation of Barmak and Minian's I-test

--- a/index.md
+++ b/index.md
@@ -19,6 +19,7 @@ to add them here.**
 * [AssociationSchemes](https://github.com/jesselansdown/AssociationSchemes) ([Homepage](https://jesselansdown.github.io/AssociationSchemes)): A GAP package for working with association schemes and homogeneous coherent configurations
 * [BruhatDecomposition](https://github.com/gap-packages/BruhatDecomposition): Computes the Bruhat decomposition of matrices in classical groups
 * [COCO2P](https://github.com/chpech/COCO2P): GAP-package for the computation with coherent configurations
+* [CompilerForCAP](https://github.com/homalg-project/CAP_project/tree/master/CompilerForCAP) ([Homepage](https://homalg-project.github.io/pkg/CompilerForCAP)): Speed up and verify categorical algorithms
 * [CoxIterGAP](https://github.com/gap-packages/CoxIterGAP): Wrapper for the [CoxIter](https://github.com/rgugliel/CoxIter) program designed to compute invariants of hyperbolic Coxeter groups
 * CTBlocks ([Homepage](https://www.math.rwth-aachen.de/~Thomas.Breuer/ctblocks)): Blocks of Character Tables
 * [EigenGap](https://github.com/jesselansdown/EigenGap): Using the Eigen C++ library within GAP

--- a/index.md
+++ b/index.md
@@ -35,7 +35,7 @@ to add them here.**
     * [GraphBacktracking](https://github.com/peal/GraphBacktracking) ([Homepage](https://peal.github.io/GraphBacktracking)): A simple but slow implementation of graph backtracking
     * [Vole](https://github.com/peal/vole) ([Homepage](https://peal.github.io/vole)): Vole organises lengthy explorations: Backtrack search in permutation groups with graphs
 * [Posets](https://github.com/isadofschi/posets): GAP Package for posets and finite spaces
-* [QuickCheck](https://github.com/ChrisJefferson/QuickCheck): A "QuickCheck" library for the GAP language
+* [QuickCheck](https://github.com/ChrisJefferson/QuickCheck) ([Homepage](https://gap-packages.github.io/quickcheck)): A "QuickCheck" library for the GAP language
 * [Satisfiability](https://github.com/MathieuDutSik/Satisfiability): functionality to solve satisfiability constraint problems and access to minisat
 * [semigroupviz](https://github.com/nathancarter/semigroupviz) ([Homepage](https://nathancarter.github.io/semigroupviz)): Visualization tools for semigroups in GAP
 * [SmallCancellation](https://github.com/isadofschi/smallcancellation): Metric and nonmetric small cancellation conditions

--- a/index.md
+++ b/index.md
@@ -45,6 +45,7 @@ to add them here.**
 * [Satisfiability](https://github.com/MathieuDutSik/Satisfiability): functionality to solve satisfiability constraint problems and access to minisat
 * [semigroupviz](https://github.com/nathancarter/semigroupviz) ([Homepage](https://nathancarter.github.io/semigroupviz)): Visualization tools for semigroups in GAP
 * [SmallCancellation](https://github.com/isadofschi/smallcancellation): Metric and nonmetric small cancellation conditions
+* [TopcomInterface](https://github.com/homalg-project/ToricVarieties_project/tree/master/TopcomInterface) ([Homepage](https://homalg-project.github.io/ToricVarieties_project/TopcomInterface)): A package to communicate with the software Topcom
 * [WeylModules](https://github.com/srdoty/WeylModulesNew) ([Homepage](https://srdoty.github.io/WeylModulesNew/)): Functions for doing computations with Weyl modules in positive characteristic for a simple simply-connected algebraic group
 * [YAGS](https://github.com/yags/yags) ([Homepage](http://xamanek.izt.uam.mx/yags)): YAGS - Yet Another Graph System
 

--- a/index.md
+++ b/index.md
@@ -26,6 +26,7 @@ to add them here.**
 * [glabella](https://github.com/nagygp/glabella) ([Homepage](https://nagygp.github.io/glabella)): Low level interfaces to graph automorphism and canonical labelling tools
 * [GRPS1024](https://github.com/davidburrell/GRPS1024) ([Homepage](https://davidburrell.github.io/GRPS1024/)): Library of the groups of order 1024
 * [Gurobify](https://github.com/jesselansdown/Gurobify) ([Homepage](https://jesselansdown.github.io/Gurobify)): A GAP interface to Gurobi Optimizer
+* [IdPGroup](https://www.iaa.tu-bs.de/henschan/so.html): Identification functions for different p-groups
 * [IncidenceStructures](https://github.com/nagygp/IncidenceStructures) ([Homepage](https://nagygp.github.io/IncidenceStructures)): GAP implementation of abstract incidence structures
 * [Itest](https://github.com/isadofschi/itest): An implementation of Barmak and Minian's I-test
 * [orders](https://github.com/feisele/orders): A GAP package for computations with orders over the p-adic integers

--- a/index.md
+++ b/index.md
@@ -26,7 +26,7 @@ to add them here.**
 * [glabella](https://github.com/nagygp/glabella) ([Homepage](https://nagygp.github.io/glabella)): Low level interfaces to graph automorphism and canonical labelling tools
 * [GRPS1024](https://github.com/davidburrell/GRPS1024) ([Homepage](https://davidburrell.github.io/GRPS1024/)): Library of the groups of order 1024
 * [Gurobify](https://github.com/jesselansdown/Gurobify) ([Homepage](https://jesselansdown.github.io/Gurobify)): A GAP interface to Gurobi Optimizer
-* [IdPGroup](https://www.iaa.tu-bs.de/henschan/so.html): Identification functions for different p-groups
+* IdPGroup ([Homepage](https://www.iaa.tu-bs.de/henschan/so.html)): Identification functions for different p-groups
 * [IncidenceStructures](https://github.com/nagygp/IncidenceStructures) ([Homepage](https://nagygp.github.io/IncidenceStructures)): GAP implementation of abstract incidence structures
 * [Itest](https://github.com/isadofschi/itest): An implementation of Barmak and Minian's I-test
 * [orders](https://github.com/feisele/orders): A GAP package for computations with orders over the p-adic integers

--- a/index.md
+++ b/index.md
@@ -18,6 +18,7 @@ to add them here.**
 
 * [AssociationSchemes](https://github.com/jesselansdown/AssociationSchemes) ([Homepage](https://jesselansdown.github.io/AssociationSchemes)): A GAP package for working with association schemes and homogeneous coherent configurations
 * [BruhatDecomposition](https://github.com/gap-packages/BruhatDecomposition): Computes the Bruhat decomposition of matrices in classical groups
+* [Char0Gauss](https://github.com/gap-packages/Char0Gauss): Linear algebra stuff
 * [COCO2P](https://github.com/chpech/COCO2P): GAP-package for the computation with coherent configurations
 * [CompilerForCAP](https://github.com/homalg-project/CAP_project/tree/master/CompilerForCAP) ([Homepage](https://homalg-project.github.io/pkg/CompilerForCAP)): Speed up and verify categorical algorithms
 * [CoxIterGAP](https://github.com/gap-packages/CoxIterGAP): Wrapper for the [CoxIter](https://github.com/rgugliel/CoxIter) program designed to compute invariants of hyperbolic Coxeter groups


### PR DESCRIPTION
### Added:

- `Char0Gauss`
- `CompilerForCAP`
- `CTBlocks`
- `GRPS39`
- `Homology`
- `IdPGroup`
- `NautyTracesInterface`
- `TopcomInterface`

`IdPGroup` is a recent package. The others I added because they are currently suggested by one or more packages distributed with GAP, or because they are otherwise "related" to packages currently on the list.

### Removed:

- `ModularGroup`
- `Origami`
- `SmallClassNr`
- `TwistedConjugacy`

All of these are now distributed with GAP.

### Updated:

- `QuickCheck`: added homepage

---

Packages that are suggested by other, distributed packages, which are **not** added by this PR

- `mfer`: "not yet publicly available"
- `chevie`: seems to be a GAP 3 package
- `ParGAP`: listed on the GAP website as "no longer distributed", and no longer compiles as of GAP 4.9